### PR TITLE
Add block template retrieval feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Block Template Retrieval
+```rust
+    let local = LocalSet::new();
+    local.run_until(async {
+        let blocktalk = BlockTalk::init("/path/to/node.sock").await?;
+
+        let block_template_interface = blocktalk.block_template();
+        let template = block_template_interface.get_block_template().await?;
+    }).await;
+```
+
 ### Try Out Examples
 
 ```bash 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     local.run_until(async {
         let blocktalk = BlockTalk::init("/path/to/node.sock").await?;
 
-        let block_template_interface = blocktalk.block_template();
-        let template = block_template_interface.get_block_template().await?;
+        let mining_interface = blocktalk.mining();
+        let template = mining_interface.get_block_template().await?;
     }).await;
 ```
 

--- a/blocktalk/src/block_template.rs
+++ b/blocktalk/src/block_template.rs
@@ -1,0 +1,37 @@
+use crate::mining_capnp::block_template::Client as BlockTemplateClient;
+use crate::proxy_capnp::thread::Client as ThreadClient;
+
+#[derive(Clone)]
+pub struct BlockTemplateInterface {
+    client: BlockTemplateClient,
+    thread: ThreadClient,
+}
+
+impl BlockTemplateInterface{
+    pub fn new(client: BlockTemplateClient, thread: ThreadClient) -> Self {
+        Self { client, thread }
+    }
+
+    pub async fn get_block_template(&self) -> Result<Vec<u8>, capnp::Error> {
+        log::info!("Retrieving new block template");
+        let mut request = self.client.get_block_request();
+
+        // Set the thread context
+        request
+            .get()
+            .get_context()?
+            .set_thread(self.thread.clone());
+
+        let response = request.send().promise.await?;
+        let results = response.get()?;
+        
+        // Extract the block data and convert to Vec<u8>
+        let block_data = results.get_result()?;
+        
+        // Convert to Vec<u8>
+        let block_bytes = block_data.to_vec();
+        
+        log::info!("Retrieved new block template");
+        Ok(block_bytes)
+    }
+}

--- a/blocktalk/src/connection.rs
+++ b/blocktalk/src/connection.rs
@@ -7,6 +7,7 @@ use crate::chain_capnp::chain::Client as ChainClient;
 use crate::init_capnp::init::Client as InitClient;
 use crate::proxy_capnp::thread::Client as ThreadClient;
 use crate::BlockTalkError;
+use crate::mining_capnp::block_template::Client as BlockTemplateClient;
 
 /// Represents a connection to the Bitcoin node
 pub struct Connection {
@@ -14,6 +15,7 @@ pub struct Connection {
     disconnector: capnp_rpc::Disconnector<twoparty::VatId>,
     thread: ThreadClient,
     chain_client: ChainClient,
+    block_template_client: BlockTemplateClient
 }
 
 impl Connection {
@@ -62,12 +64,37 @@ impl Connection {
         let chain_client = response.get()?.get_result()?;
         log::debug!("Chain client established");
 
+        // Set up block template client with thread context
+        let mut mk_mining_req = init_interface.make_mining_request();
+        {
+            let mut context = mk_mining_req.get().get_context()?;
+            context.set_thread(thread.clone());
+        }
+        let response = mk_mining_req.send().promise.await?;
+
+        let mining_client = response.get()?.get_result()?;
+        log::debug!("Mining client established");
+
+        // Now create a new block to get the block template client
+        let mut create_block_req = mining_client.create_new_block_request();
+        {
+            // Set up the options for creating a new block
+            let mut options = create_block_req.get().init_options();
+            options.set_use_mempool(true);
+            options.set_block_reserved_weight(4000);
+        }
+        let response = create_block_req.send().promise.await?;
+
+        let block_template_client = response.get()?.get_result()?;
+        log::debug!("Block template client established");
+
         log::info!("Connection to node established successfully");
         Ok(Arc::new(Self {
             rpc_handle,
             disconnector,
             thread,
             chain_client,
+            block_template_client
         }))
     }
 
@@ -88,6 +115,11 @@ impl Connection {
     /// Get a reference to the chain client
     pub fn chain_client(&self) -> &ChainClient {
         &self.chain_client
+    }
+
+    /// Get the mining client
+    pub fn block_template_client(&self) -> BlockTemplateClient {
+        self.block_template_client.clone()
     }
 
     /// Get a reference to the thread client

--- a/blocktalk/src/lib.rs
+++ b/blocktalk/src/lib.rs
@@ -6,12 +6,12 @@ mod error;
 mod generated;
 mod mempool;
 mod notification;
-mod block_template;
+mod mining;
 
 pub use bitcoin::BlockHash;
 pub use chain::{Blockchain, ChainInterface};
 pub use connection::{Connection, ConnectionProvider, UnixConnectionProvider};
-pub use block_template::BlockTemplateInterface;
+pub use mining::{MiningInterface, Mining};
 pub use error::BlockTalkError;
 pub use generated::*;
 pub use mempool::{Mempool, MempoolInterface, TransactionAncestry};
@@ -23,7 +23,7 @@ pub struct BlockTalk {
     connection: Arc<Connection>,
     chain: Arc<dyn ChainInterface>,
     mempool: Arc<dyn MempoolInterface>,
-    block_template_interface: BlockTemplateInterface
+    mining: Arc<dyn MiningInterface>
 }
 
 impl BlockTalk {
@@ -35,15 +35,15 @@ impl BlockTalk {
             connection.chain_client().clone(),
             connection.thread().clone(),
         ));
-        let block_template_client = connection.block_template_client();
+        let mining_client = connection.mining_client();
         let thread_client = connection.thread().clone();
-        let block_template_interface = BlockTemplateInterface::new(block_template_client, thread_client);
+        let mining = Arc::new(Mining::new(mining_client, thread_client));
         log::info!("BlockTalk initialized successfully");
 
         Ok(Self {
             connection,
             chain,
-            block_template_interface,
+            mining,
             mempool,
         })
     }
@@ -53,7 +53,7 @@ impl BlockTalk {
         chain_provider: Box<dyn ConnectionProvider>,
         chain_interface: Arc<dyn ChainInterface>,
         mempool_interface: Arc<dyn MempoolInterface>,
-        block_template_interface: BlockTemplateInterface
+        mining_interface: Arc<dyn MiningInterface>
     ) -> Result<Self, BlockTalkError> {
         log::info!(
             "Initializing BlockTalk with socket path: {} and custom provider",
@@ -66,7 +66,7 @@ impl BlockTalk {
             connection,
             chain: chain_interface,
             mempool: mempool_interface,
-            block_template_interface
+            mining: mining_interface
         })
     }
 
@@ -78,8 +78,8 @@ impl BlockTalk {
         &self.mempool
     }
 
-    pub fn block_template(&self) -> &BlockTemplateInterface {
-        &self.block_template_interface
+    pub fn mining(&self) -> &Arc<dyn MiningInterface> {
+        &self.mining
     }
 
     /// Disconnect from the node

--- a/blocktalk/src/mining.rs
+++ b/blocktalk/src/mining.rs
@@ -1,18 +1,28 @@
-use crate::mining_capnp::block_template::Client as BlockTemplateClient;
+// use crate::mining_capnp::block_template::Client as BlockTemplateClient;
+use crate::mining_capnp::block_template::Client as MiningClient;
 use crate::proxy_capnp::thread::Client as ThreadClient;
 
+#[async_trait::async_trait(?Send)]
+pub trait MiningInterface {
+    /// Get a block template
+    async fn get_block_template(&self) -> Result<Vec<u8>, capnp::Error>;
+}
+
 #[derive(Clone)]
-pub struct BlockTemplateInterface {
-    client: BlockTemplateClient,
+pub struct Mining {
+    client: MiningClient,
     thread: ThreadClient,
 }
 
-impl BlockTemplateInterface{
-    pub fn new(client: BlockTemplateClient, thread: ThreadClient) -> Self {
+impl Mining {
+    pub fn new(client: MiningClient, thread: ThreadClient) -> Self {
         Self { client, thread }
     }
+}
 
-    pub async fn get_block_template(&self) -> Result<Vec<u8>, capnp::Error> {
+#[async_trait::async_trait(?Send)]
+impl MiningInterface for Mining {
+    async fn get_block_template(&self) -> Result<Vec<u8>, capnp::Error> {
         log::info!("Retrieving new block template");
         let mut request = self.client.get_block_request();
 


### PR DESCRIPTION
This PR adds support for block template retrieval via the IPC interface. Obtaining block templates from a node is an important part of the mining process. Miners can add their own transactions before mining and submitting the block. An example is added to the README to show usage in a downstream repository.  